### PR TITLE
Fix bitwise shift operator syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 loopring/loopring"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "^0.29.0",
-    "@graphprotocol/graph-ts": "^0.26.0"
+    "@graphprotocol/graph-cli": "^0.59.0",
+    "@graphprotocol/graph-ts": "^0.31.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopring",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "codegen": "graph codegen",

--- a/schema.graphql
+++ b/schema.graphql
@@ -160,7 +160,7 @@ type Pair @entity {
   weeklyEntities: [PairWeeklyData!]! @derivedFrom(field: "pair")
 }
 
-type Block @entity {
+type Block @entity(immutable: true) {
   id: ID!
 
   "Same as ID but expressed as a BigInt so it can be used for sorting properly"
@@ -413,7 +413,7 @@ type AccountTokenBalance @entity {
     @derivedFrom(field: "accountTokenBalance")
 }
 
-type NonFungibleToken @entity {
+type NonFungibleToken @entity(immutable: true) {
   "ID is the Poseidon hash reported by L2"
   id: ID!
 
@@ -530,7 +530,7 @@ interface TransactionNFT {
   slots: [AccountNFTSlot!]!
 }
 
-type Deposit implements Transaction @entity {
+type Deposit implements Transaction @entity(immutable: true) {
   id: ID!
 
   "Explicit copy of __typename to make it usable when filtering"
@@ -564,7 +564,7 @@ type Deposit implements Transaction @entity {
   accounts: [Account!]
 }
 
-type Withdrawal implements Transaction @entity {
+type Withdrawal implements Transaction @entity(immutable: true) {
   id: ID!
 
   "Explicit copy of __typename to make it usable when filtering"
@@ -614,7 +614,7 @@ type Withdrawal implements Transaction @entity {
   accounts: [Account!]
 }
 
-type WithdrawalNFT implements Transaction & TransactionNFT @entity {
+type WithdrawalNFT implements Transaction & TransactionNFT @entity(immutable: true) {
   id: ID!
 
   "Explicit copy of __typename to make it usable when filtering"
@@ -668,7 +668,7 @@ type WithdrawalNFT implements Transaction & TransactionNFT @entity {
   slots: [AccountNFTSlot!]!
 }
 
-type Transfer implements Transaction @entity {
+type Transfer implements Transaction @entity(immutable: true) {
   id: ID!
 
   "Explicit copy of __typename to make it usable when filtering"
@@ -722,7 +722,7 @@ type Transfer implements Transaction @entity {
   accounts: [Account!]
 }
 
-type TransferNFT implements Transaction & TransactionNFT @entity {
+type TransferNFT implements Transaction & TransactionNFT @entity(immutable: true) {
   id: ID!
 
   "Explicit copy of __typename to make it usable when filtering"
@@ -783,7 +783,7 @@ type TransferNFT implements Transaction & TransactionNFT @entity {
   slots: [AccountNFTSlot!]!
 }
 
-type Add implements Transaction @entity {
+type Add implements Transaction @entity(immutable: true) {
   id: ID!
 
   "Explicit copy of __typename to make it usable when filtering"
@@ -837,7 +837,7 @@ type Add implements Transaction @entity {
   accounts: [Account!]
 }
 
-type Remove implements Transaction @entity {
+type Remove implements Transaction @entity(immutable: true) {
   id: ID!
 
   "Explicit copy of __typename to make it usable when filtering"
@@ -891,7 +891,7 @@ type Remove implements Transaction @entity {
   accounts: [Account!]
 }
 
-type OrderbookTrade implements Transaction @entity {
+type OrderbookTrade implements Transaction @entity(immutable: true) {
   id: ID!
 
   "Explicit copy of __typename to make it usable when filtering"
@@ -997,7 +997,7 @@ type OrderbookTrade implements Transaction @entity {
   accounts: [Account!]
 }
 
-type Swap implements Transaction @entity {
+type Swap implements Transaction @entity(immutable: true) {
   id: ID!
 
   "Explicit copy of __typename to make it usable when filtering"
@@ -1103,7 +1103,7 @@ type Swap implements Transaction @entity {
   accounts: [Account!]
 }
 
-type TradeNFT implements Transaction & TransactionNFT @entity {
+type TradeNFT implements Transaction & TransactionNFT @entity(immutable: true) {
   id: ID!
 
   "Explicit copy of __typename to make it usable when filtering"
@@ -1210,7 +1210,7 @@ type TradeNFT implements Transaction & TransactionNFT @entity {
   slots: [AccountNFTSlot!]!
 }
 
-type SwapNFT implements Transaction & TransactionNFT @entity {
+type SwapNFT implements Transaction & TransactionNFT @entity(immutable: true) {
   id: ID!
 
   "Explicit copy of __typename to make it usable when filtering"
@@ -1306,7 +1306,7 @@ type SwapNFT implements Transaction & TransactionNFT @entity {
   slots: [AccountNFTSlot!]!
 }
 
-type AccountUpdate implements Transaction @entity {
+type AccountUpdate implements Transaction @entity(immutable: true) {
   id: ID!
 
   "Explicit copy of __typename to make it usable when filtering"
@@ -1346,7 +1346,7 @@ type AccountUpdate implements Transaction @entity {
   accounts: [Account!]
 }
 
-type AmmUpdate implements Transaction @entity {
+type AmmUpdate implements Transaction @entity(immutable: true) {
   id: ID!
 
   "Explicit copy of __typename to make it usable when filtering"
@@ -1378,7 +1378,7 @@ type AmmUpdate implements Transaction @entity {
   accounts: [Account!]
 }
 
-type SignatureVerification implements Transaction @entity {
+type SignatureVerification implements Transaction @entity(immutable: true) {
   id: ID!
 
   "Explicit copy of __typename to make it usable when filtering"
@@ -1407,7 +1407,7 @@ type SignatureVerification implements Transaction @entity {
   accounts: [Account!]
 }
 
-type MintNFT implements Transaction & TransactionNFT @entity {
+type MintNFT implements Transaction & TransactionNFT @entity(immutable: true) {
   id: ID!
 
   "Explicit copy of __typename to make it usable when filtering"
@@ -1458,7 +1458,7 @@ type MintNFT implements Transaction & TransactionNFT @entity {
   slots: [AccountNFTSlot!]!
 }
 
-type DataNFT implements Transaction & TransactionNFT @entity {
+type DataNFT implements Transaction & TransactionNFT @entity(immutable: true) {
   id: ID!
 
   "Explicit copy of __typename to make it usable when filtering"

--- a/src/mappings/exchangev3.ts
+++ b/src/mappings/exchangev3.ts
@@ -10,7 +10,6 @@ import { Block, Proxy } from "../../generated/schema";
 import {
   getOrCreateToken,
   getProxy,
-  getOrCreateBlock,
   processBlockData,
   intToString
 } from "../utils/helpers";
@@ -59,9 +58,29 @@ function handleSubmitBlocks(
     proxy.blockCount = proxy.blockCount.plus(BIGINT_ONE);
 
     let blockData = blockArray[i];
-    let block = getOrCreateBlock(proxy.blockCount);
-
+    let block = new Block(proxy.blockCount.toString());
+    
+    // conditionally updated
+    block.transactionCount = BIGINT_ZERO;
+    block.depositCount = BIGINT_ZERO;
+    block.withdrawalCount = BIGINT_ZERO;
+    block.withdrawalNFTCount = BIGINT_ZERO;
+    block.transferCount = BIGINT_ZERO;
+    block.transferNFTCount = BIGINT_ZERO;
+    block.addCount = BIGINT_ZERO;
+    block.removeCount = BIGINT_ZERO;
+    block.orderbookTradeCount = BIGINT_ZERO;
+    block.swapCount = BIGINT_ZERO;
+    block.swapNFTCount = BIGINT_ZERO;
+    block.tradeNFTCount = BIGINT_ZERO;
+    block.accountUpdateCount = BIGINT_ZERO;
+    block.ammUpdateCount = BIGINT_ZERO;
+    block.signatureVerificationCount = BIGINT_ZERO;
+    block.nftMintCount = BIGINT_ZERO;
+    block.nftDataCount = BIGINT_ZERO;
+    
     // metadata
+    block.internalID = proxy.blockCount;
     block.txHash = call.transaction.hash.toHexString();
     block.gasLimit = call.transaction.gasLimit;
     block.gasPrice = call.transaction.gasPrice;

--- a/src/utils/helpers/block.ts
+++ b/src/utils/helpers/block.ts
@@ -33,35 +33,6 @@ import {
   processNFTData
 } from "./transactionProcessors";
 
-export function getOrCreateBlock(internalID: BigInt): Block {
-  let id = internalID.toString();
-  let block = Block.load(id);
-
-  if (block == null) {
-    block = new Block(id);
-    block.internalID = internalID;
-    block.transactionCount = BIGINT_ZERO;
-    block.depositCount = BIGINT_ZERO;
-    block.withdrawalCount = BIGINT_ZERO;
-    block.withdrawalNFTCount = BIGINT_ZERO;
-    block.transferCount = BIGINT_ZERO;
-    block.transferNFTCount = BIGINT_ZERO;
-    block.addCount = BIGINT_ZERO;
-    block.removeCount = BIGINT_ZERO;
-    block.orderbookTradeCount = BIGINT_ZERO;
-    block.swapCount = BIGINT_ZERO;
-    block.swapNFTCount = BIGINT_ZERO;
-    block.tradeNFTCount = BIGINT_ZERO;
-    block.accountUpdateCount = BIGINT_ZERO;
-    block.ammUpdateCount = BIGINT_ZERO;
-    block.signatureVerificationCount = BIGINT_ZERO;
-    block.nftMintCount = BIGINT_ZERO;
-    block.nftDataCount = BIGINT_ZERO;
-  }
-
-  return block as Block;
-}
-
 export function processBlockData(block: Block, proxy: Proxy): Block {
   let data = block.data.slice(2); // Remove the 0x beginning of the hex string
   let offset = 0;

--- a/src/utils/helpers/index.ts
+++ b/src/utils/helpers/index.ts
@@ -1,6 +1,6 @@
-export { getOrCreateBlock, processBlockData } from "./block";
+export { processBlockData } from "./block";
 
-export { getOrCreateNFT, getOrCreateAccountNFTSlot } from "./nft";
+export { getOrCreateAccountNFTSlot } from "./nft";
 
 export {
   getOrCreateToken,

--- a/src/utils/helpers/nft.ts
+++ b/src/utils/helpers/nft.ts
@@ -7,25 +7,6 @@ import { BigInt, Bytes } from "@graphprotocol/graph-ts";
 import { compoundId, intToString, compoundIdToSortableDecimal } from "./util";
 import { ZERO_ADDRESS, BIGINT_ZERO, BIGINT_ONE } from "../constants";
 
-export function getOrCreateNFT(
-  id: String,
-  transactionId: String,
-  proxy: Proxy,
-  createIfNotFound: boolean = true
-): NonFungibleToken {
-  let nft = NonFungibleToken.load(id);
-
-  if (nft == null && createIfNotFound) {
-    nft = new NonFungibleToken(id);
-    nft.mintedAt = compoundIdToSortableDecimal(transactionId);
-    nft.mintedAtTransaction = transactionId;
-
-    proxy.nftCount = proxy.nftCount.plus(BIGINT_ONE);
-  }
-
-  return nft as NonFungibleToken;
-}
-
 export function getOrCreateAccountNFTSlot(
   accountId: i32,
   tokenId: i32,

--- a/src/utils/helpers/transactionProcessors/nftMint.ts
+++ b/src/utils/helpers/transactionProcessors/nftMint.ts
@@ -20,7 +20,6 @@ import {
   intToString,
   getOrCreateAccountTokenBalance,
   compoundIdToSortableDecimal,
-  getOrCreateNFT,
   getOrCreateAccountNFTSlot,
   getAndUpdateAccountTokenBalanceDailyData,
   getAndUpdateAccountTokenBalanceWeeklyData
@@ -282,7 +281,11 @@ export function processNFTMint(
     .concat(transaction.nftID)
     .concat("-")
     .concat(intToString(transaction.creatorFeeBips));
-  let nft = getOrCreateNFT(nftID, transaction.id, proxy);
+
+  let nft = new NonFungibleToken(nftID);
+
+  nft.mintedAt = compoundIdToSortableDecimal(transaction.id);
+  nft.mintedAtTransaction = transaction.id;
   nft.minter = intToString(transaction.minterAccountID);
   nft.nftType = transaction.nftType;
   nft.token = transaction.tokenAddress;
@@ -291,6 +294,7 @@ export function processNFTMint(
   nft.save();
 
   nfts.push(nft.id);
+  proxy.nftCount = proxy.nftCount.plus(BIGINT_ONE);
 
   let receiverAccountNFTSlot = getOrCreateAccountNFTSlot(
     transaction.toAccountID,

--- a/src/utils/helpers/transactionProcessors/spotTrade.ts
+++ b/src/utils/helpers/transactionProcessors/spotTrade.ts
@@ -415,13 +415,13 @@ export function processSpotTrade(
   // Further extraction of packed data
   transaction.limitMaskA = transaction.orderDataA & stringBytesToBigInt("80");
   transaction.feeBipsA =
-    (transaction.feeBipsHiA << 6) |
+    transaction.feeBipsHiA.leftShift(6) |
     (transaction.orderDataA & stringBytesToBigInt("3F"));
   transaction.fillAmountBorSA = transaction.limitMaskA > BIGINT_ZERO;
 
   transaction.limitMaskB = transaction.orderDataB & stringBytesToBigInt("80");
   transaction.feeBipsB =
-    (transaction.feeBipsHiB << 6) |
+    transaction.feeBipsHiB.leftShift(6) |
     (transaction.orderDataB & stringBytesToBigInt("3F"));
   transaction.fillAmountBorSB = transaction.limitMaskB > BIGINT_ZERO;
 

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -12,7 +12,7 @@ dataSources:
       startBlock: 11149814
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.6
+      apiVersion: 0.0.7
       language: wasm/assemblyscript
       file: ./src/index.ts
       entities:

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -1,4 +1,4 @@
-specVersion: 0.0.2
+specVersion: 0.0.4
 description: Loopring Exchange V3 (Loopring 3.6.5) subgraph. Supports L2 Blocks and Transactions, as well as L2 accounts, balances and more.
 schema:
   file: ./schema.graphql
@@ -12,7 +12,7 @@ dataSources:
       startBlock: 11149814
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.5
+      apiVersion: 0.0.6
       language: wasm/assemblyscript
       file: ./src/index.ts
       entities:


### PR DESCRIPTION
- Issue: changed syntax for bitwise left-shift operator on graph-ts version upgrade
- Ref: section `Math` under [BigInt](https://thegraph.com/docs/en/developing/assemblyscript-api/#bigint)
- Test Deployment: https://thegraph.com/hosted-service/subgraph/dhruv-chauhan/loopring
- Query: https://api.thegraph.com/subgraphs/name/dhruv-chauhan/loopring/graphql?query=%7B%0A++orderbookTrades%7B%0A++++id%0A++++feeBipsA%0A++++feeBipsB%0A++%7D%0A%7D
- Performance: made entities which do not need updating immutable